### PR TITLE
Fix: Fractional Values Not Displayed Correctly Due to parseInt Usage

### DIFF
--- a/src/components/RulerPicker.tsx
+++ b/src/components/RulerPicker.tsx
@@ -282,16 +282,16 @@ export const RulerPicker: React.FC<RulerPickerProps> = ({
     <View pointerEvents="none" style={[styles.displayTextContainer]}>
       {showLabels &&
         getLabel(
-          parseInt(prevValue.current) - step * 2 >= min
-            ? (parseInt(prevValue.current) - step * 2).toString()
+          Number(prevValue.current) - step * 2 >= min
+            ? (Number(prevValue.current) - step * 2).toFixed(fractionDigits).toString()
             : '',
           'lightgray'
         )}
 
       {showLabels &&
         getLabel(
-          parseInt(prevValue.current) - step >= min
-            ? (parseInt(prevValue.current) - step).toString()
+          Number(prevValue.current) - step >= min
+            ? (Number(prevValue.current) - step).toFixed(fractionDigits).toString()
             : '',
           'gray'
         )}
@@ -302,24 +302,24 @@ export const RulerPicker: React.FC<RulerPickerProps> = ({
           numberOfLines={1}
           adjustsFontSizeToFit
         >
-          {parseInt(prevValue.current).toFixed(fractionDigits)}{' '}
+          {Number(prevValue.current).toFixed(fractionDigits)}{' '}
           {unit && <Text style={[styles.unitText, unitTextStyle]}>{unit}</Text>}
         </Text>
       </View>
 
       {showLabels &&
         getLabel(
-          parseInt(prevValue.current) + step >= max + step
+          Number(prevValue.current) + step >= max + step
             ? ''
-            : (parseInt(prevValue.current) + step).toString(),
+            : (Number(prevValue.current) + step).toFixed(fractionDigits).toString(),
           'gray'
         )}
 
       {showLabels &&
         getLabel(
-          parseInt(prevValue.current) + step * 2 >= max + step
+          Number(prevValue.current) + step * 2 >= max + step
             ? ''
-            : (parseInt(prevValue.current) + step * 2).toString(),
+            : (Number(prevValue.current) + step * 2).toFixed(fractionDigits).toString(),
           'lightgray'
         )}
     </View>


### PR DESCRIPTION
Hi! 👋

Firstly, thanks for your work on this project! 🙂

Issue:
When using the ruler with fractional units (e.g., 0.1, 0.25), the displayed value doesn't update correctly. This happens because parseInt() is used on the value before rendering, which causes the fractional part to be discarded. As a result, values like 1.5 are parsed as 1, and the UI doesn't reflect the correct measurement.

Fix:
I replaced all instances of parseInt(prevValue.current) with Number(prevValue.current) and formatted the result using .toFixed(fractionDigits). This ensures that fractional values are preserved and displayed correctly in the ruler view.